### PR TITLE
Auto Tag Workflow ID Based on the ports defined in mappings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,29 +13,82 @@ cd MicroModel
 npm install
 ```
 
-2. Create `.env` file:
+2. Create `mappings.json` file (optional):
+```json
+{
+  "workflow_id_1": 3001,
+  "workflow_id_2": 3002,
+  "training_batch_alpha": 3003,
+  "production_test": 3004
+}
+```
+
+3. Create `.env` file:
 ```env
 OPENAI_API_BASE_URL=http://localhost:11434
 OPENAI_API_KEY=your-api-key
 PORT=36830
 ```
 
-3. Start the server:
+4. Start the server:
 ```bash
 npm run dev
 ```
 
+The server will automatically start multiple instances based on your `mappings.json`:
+- Each port maps to a specific `workflow_id`
+- If no `mappings.json` exists, runs on port defined in the env
+
+## Port-Based Workflow Mapping
+
+When you create a `mappings.json` file, MicroModel automatically:
+1. Starts multiple server instances - one for each port defined
+2. Auto-assigns workflow_id - based on which port receives the request
+3. Organizes data collection - each workflow gets its own data directory
+
+### Example Setup
+
+With this `mappings.json`:
+```json
+{
+  "user_feedback": 3001,
+  "automated_tests": 3002,
+  "production_logs": 3003
+}
+```
+
+You get three separate endpoints:
+- `http://localhost:3001/v1/completions` → automatically uses `workflow_id: "user_feedback"`
+- `http://localhost:3002/v1/completions` → automatically uses `workflow_id: "automated_tests"` 
+- `http://localhost:3003/v1/completions` → automatically uses `workflow_id: "production_logs"`
+
 ## Usage
 
-Send requests to `http://localhost:36830/v1/completions` with a `workflow_id`. This will capture the prompt and completion of the model:
+### Option 1: Port-Based Automatic Assignment (Recommended)
+Simply send requests to the mapped port - no need to include `workflow_id` in the body:
+
+```bash
+# Automatically uses workflow_id: "user_feedback"
+curl -X POST http://localhost:3001/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3:0.6b",
+    "prompt": "Tell me a story"
+  }'
+```
+
+### Option 2: Manual workflow_id Assignment
+Send requests with explicit `workflow_id` (works on any port):
 
 ```json
 {
   "model": "qwen3:0.6b",
   "prompt": "Tell me a story",
-  "workflow_id": "workflow_id"
+  "workflow_id": "custom_workflow"
 }
 ```
+
+**Note**: Manual `workflow_id` in the request body overrides the port-based assignment.
 
 ## Data Collection
 

--- a/mappings.json
+++ b/mappings.json
@@ -1,0 +1,4 @@
+{
+  "workflow_id_1": 3001,
+  "workflow_id_2": 3002
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,8 +96,7 @@ const createApp = (workflowId: string): Application => {
       delete forwardBody.workflow_id;
       
       // Log the incoming request
-      console.log(`[Port mapping] Proxying request to ${OPENAI_API_BASE_URL}/v1/completions`);
-      console.log(`[Port mapping] Workflow ID: ${finalWorkflowId}`);
+      console.log(`Proxying request to ${OPENAI_API_BASE_URL}/v1/completions for ${finalWorkflowId}`);
       
       // Forward request to OpenAI API
       const controller = new AbortController();
@@ -119,7 +118,7 @@ const createApp = (workflowId: string): Application => {
             'Content-Type': 'application/json',
             ...forwardHeaders
           },
-          body: JSON.stringify(forwardBody), // Use cleaned body without workflow_id
+          body: JSON.stringify(forwardBody),
           signal: controller.signal
         }
       );
@@ -195,9 +194,11 @@ const startServers = () => {
     // Start default server
     const defaultApp = createApp('default');
     const defaultServer = defaultApp.listen(3000, () => {
+      console.log('='.repeat(60));
       console.log('Default OpenAI Proxy Server is running on port 3000');
       console.log(`Forwarding requests to: ${OPENAI_API_BASE_URL}`);
       console.log('Default workflow_id: default');
+      console.log('='.repeat(60));
     });
     
     setupErrorHandling(defaultServer, 3000);
@@ -212,9 +213,11 @@ const startServers = () => {
     const app = createApp(workflowId);
     
     const server = app.listen(port, () => {
+      console.log('='.repeat(60));
       console.log(`OpenAI Proxy Server is running on port ${port}`);
       console.log(`Workflow ID: ${workflowId}`);
       console.log(`Forwarding requests to: ${OPENAI_API_BASE_URL}`);
+      console.log('='.repeat(60));
     });
 
     setupErrorHandling(server, port);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,20 +6,35 @@ import path from 'path';
 // Load environment variables
 dotenv.config();
 
-const app: Application = express();
-const PORT = process.env.PORT || 3000;
 const OPENAI_API_BASE_URL = process.env.OPENAI_API_BASE_URL || 'https://api.openai.com';
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+// Load mappings from mappings.json
+const loadMappings = (): { [key: string]: number } => {
+  try {
+    const mappingsPath = path.join(__dirname, '..', 'mappings.json');
+    const mappingsData = fs.readFileSync(mappingsPath, 'utf8');
+    return JSON.parse(mappingsData);
+  } catch (error) {
+    console.error('Error loading mappings.json:', error);
+    return {};
+  }
+};
+
+// Create reverse mapping: port -> workflow_id
+const createPortToWorkflowMapping = (mappings: { [key: string]: number }): { [port: number]: string } => {
+  const reverseMap: { [port: number]: string } = {};
+  Object.entries(mappings).forEach(([workflowId, port]) => {
+    reverseMap[port] = workflowId;
+  });
+  return reverseMap;
+};
 
 // Ensure data directory exists
 const dataDir = path.join(__dirname, '..', 'data');
 if (!fs.existsSync(dataDir)) {
   fs.mkdirSync(dataDir, { recursive: true });
 }
-
-// Middleware
-app.use(express.json({ limit: '10mb' }));
-app.use(express.urlencoded({ extended: true }));
 
 // Logging utility
 const logRequestResponse = (prompt: any, response: any, endpoint: string, workflowId?: string) => {
@@ -61,120 +76,166 @@ const logRequestResponse = (prompt: any, response: any, endpoint: string, workfl
   }
 };
 
-// Proxy route for OpenAI /v1/completions
-app.post('/v1/completions', async (req: Request, res: Response) => {
-  try {
-    const requestBody = req.body;
-    const workflowId = requestBody.workflow_id; // Extract workflow_id from request body
-    
-    // Remove workflow_id from request body before forwarding to API
-    const forwardBody = { ...requestBody };
-    delete forwardBody.workflow_id;
-    
-    // Log the incoming request
-    console.log(`Proxying request to ${OPENAI_API_BASE_URL}/v1/completions`);
-    console.log(`Workflow ID: ${workflowId || 'default'}`);
-    
-    // Forward request to OpenAI API
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 60000); // 1 minute timeout
-    
-    // Prepare headers, filtering out problematic ones
-    const forwardHeaders: Record<string, string> = {};
-    Object.entries(req.headers).forEach(([key, value]) => {
-      if (typeof value === 'string' && key.toLowerCase() !== 'host' && key.toLowerCase() !== 'content-length') {
-        forwardHeaders[key] = value;
+// Create an Express app with workflow-specific routing
+const createApp = (workflowId: string): Application => {
+  const app: Application = express();
+  
+  // Middleware
+  app.use(express.json({ limit: '10mb' }));
+  app.use(express.urlencoded({ extended: true }));
+
+  // Proxy route for OpenAI /v1/completions
+  app.post('/v1/completions', async (req: Request, res: Response) => {
+    try {
+      const requestBody = req.body;
+      // Use the workflow_id from the port mapping, but allow override from request body
+      const finalWorkflowId = requestBody.workflow_id || workflowId;
+      
+      // Remove workflow_id from request body before forwarding to API
+      const forwardBody = { ...requestBody };
+      delete forwardBody.workflow_id;
+      
+      // Log the incoming request
+      console.log(`[Port mapping] Proxying request to ${OPENAI_API_BASE_URL}/v1/completions`);
+      console.log(`[Port mapping] Workflow ID: ${finalWorkflowId}`);
+      
+      // Forward request to OpenAI API
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 60000); // 1 minute timeout
+      
+      // Prepare headers, filtering out problematic ones
+      const forwardHeaders: Record<string, string> = {};
+      Object.entries(req.headers).forEach(([key, value]) => {
+        if (typeof value === 'string' && key.toLowerCase() !== 'host' && key.toLowerCase() !== 'content-length') {
+          forwardHeaders[key] = value;
+        }
+      });
+      
+      const response = await fetch(
+        `${OPENAI_API_BASE_URL}/v1/completions`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...forwardHeaders
+          },
+          body: JSON.stringify(forwardBody), // Use cleaned body without workflow_id
+          signal: controller.signal
+        }
+      );
+      
+      clearTimeout(timeoutId);
+      
+      if (!response.ok) {
+        const errorData = await response.json();
+        return res.status(response.status).json(errorData);
+      }
+      
+      const responseData = await response.json();
+
+      // Log the prompt and response with workflow_id
+      logRequestResponse(requestBody, responseData, '/v1/completions', finalWorkflowId);
+
+      // Return the response to the client
+      res.status(response.status).json(responseData);
+
+    } catch (error: any) {
+      console.error('Error proxying request:', error.message);
+      
+      if (error.name === 'AbortError') {
+        // Request was aborted due to timeout
+        res.status(408).json({ 
+          error: 'Request timeout',
+          message: 'Request timed out after 60 seconds'
+        });
+      } else {
+        // Internal server error
+        res.status(500).json({ 
+          error: 'Internal proxy server error',
+          message: error.message 
+        });
+      }
+    }
+  });
+
+  // Health check endpoint
+  app.get('/health', (req: Request, res: Response) => {
+    res.json({ 
+      status: 'OK', 
+      timestamp: new Date().toISOString(),
+      service: 'OpenAI Proxy Service',
+      workflow_id: workflowId
+    });
+  });
+
+  // Basic info endpoint
+  app.get('/', (req: Request, res: Response) => {
+    res.json({
+      service: 'OpenAI Proxy Service',
+      description: 'Forwards requests to OpenAI API while logging prompts and responses',
+      workflow_id: workflowId,
+      endpoints: {
+        'POST /v1/completions': 'Proxy for OpenAI chat completions',
+        'GET /health': 'Health check',
+        'GET /': 'Service information'
       }
     });
-    
-    const response = await fetch(
-      `${OPENAI_API_BASE_URL}/v1/completions`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...forwardHeaders
-        },
-        body: JSON.stringify(forwardBody), // Use cleaned body without workflow_id
-        signal: controller.signal
-      }
-    );
-    
-    clearTimeout(timeoutId);
-    
-    if (!response.ok) {
-      const errorData = await response.json();
-      return res.status(response.status).json(errorData);
-    }
-    
-    const responseData = await response.json();
-
-    // Log the prompt and response with workflow_id
-    logRequestResponse(requestBody, responseData, '/v1/completions', workflowId);
-
-    // Return the response to the client
-    res.status(response.status).json(responseData);
-
-  } catch (error: any) {
-    console.error('Error proxying request:', error.message);
-    
-    if (error.name === 'AbortError') {
-      // Request was aborted due to timeout
-      res.status(408).json({ 
-        error: 'Request timeout',
-        message: 'Request timed out after 60 seconds'
-      });
-    } else {
-      // Internal server error
-      res.status(500).json({ 
-        error: 'Internal proxy server error',
-        message: error.message 
-      });
-    }
-  }
-});
-
-// Health check endpoint
-app.get('/health', (req: Request, res: Response) => {
-  res.json({ 
-    status: 'OK', 
-    timestamp: new Date().toISOString(),
-    service: 'OpenAI Proxy Service'
   });
-});
 
-// Basic info endpoint
-app.get('/', (req: Request, res: Response) => {
-  res.json({
-    service: 'OpenAI Proxy Service',
-    description: 'Forwards requests to OpenAI API while logging prompts and responses',
-    endpoints: {
-      'POST /v1/completions': 'Proxy for OpenAI chat completions',
-      'GET /health': 'Health check',
-      'GET /': 'Service information'
-    }
-  });
-});
+  return app;
+};
 
-// Start the server
-const server = app.listen(PORT, () => {
-  console.log(`OpenAI Proxy Server is running on port ${PORT}`);
-  console.log(`Forwarding requests to: ${OPENAI_API_BASE_URL}`);
-  console.log(`Logging all prompts and responses to console`);
+// Main function to start all servers
+const startServers = () => {
+  const mappings = loadMappings();
+  const portToWorkflowMapping = createPortToWorkflowMapping(mappings);
   
+  if (Object.keys(mappings).length === 0) {
+    console.warn('No mappings found in mappings.json. Starting default server on port 3000.');
+    // Start default server
+    const defaultApp = createApp('default');
+    const defaultServer = defaultApp.listen(3000, () => {
+      console.log('Default OpenAI Proxy Server is running on port 3000');
+      console.log(`Forwarding requests to: ${OPENAI_API_BASE_URL}`);
+      console.log('Default workflow_id: default');
+    });
+    
+    setupErrorHandling(defaultServer, 3000);
+    return;
+  }
+
+  console.log('Starting servers based on mappings.json:');
+  console.log(JSON.stringify(mappings, null, 2));
+
+  // Start a server for each port in the mappings
+  Object.entries(mappings).forEach(([workflowId, port]) => {
+    const app = createApp(workflowId);
+    
+    const server = app.listen(port, () => {
+      console.log(`OpenAI Proxy Server is running on port ${port}`);
+      console.log(`Workflow ID: ${workflowId}`);
+      console.log(`Forwarding requests to: ${OPENAI_API_BASE_URL}`);
+    });
+
+    setupErrorHandling(server, port);
+  });
+
   if (!OPENAI_API_KEY) {
     console.warn('Warning: OPENAI_API_KEY not set in environment variables');
   }
-});
+};
 
-// Error handling
-server.on('error', (error: any) => {
-  console.error('Server error:', error);
-  if (error.code === 'EADDRINUSE') {
-    console.error(`Port ${PORT} is already in use. Try a different port.`);
-  }
-});
+// Setup error handling for a server
+const setupErrorHandling = (server: any, port: number) => {
+  server.on('error', (error: any) => {
+    console.error(`Server error on port ${port}:`, error);
+    if (error.code === 'EADDRINUSE') {
+      console.error(`Port ${port} is already in use. Try a different port.`);
+    }
+  });
+};
 
+// Global error handling
 process.on('uncaughtException', (error) => {
   console.error('Uncaught Exception:', error);
 });
@@ -183,21 +244,17 @@ process.on('unhandledRejection', (reason, promise) => {
   console.error('Unhandled Rejection at:', promise, 'reason:', reason);
 });
 
-// Keep the process alive
 process.on('SIGTERM', () => {
   console.log('SIGTERM received. Shutting down gracefully...');
-  server.close(() => {
-    console.log('Server closed.');
-    process.exit(0);
-  });
+  process.exit(0);
 });
 
 process.on('SIGINT', () => {
   console.log('SIGINT received. Shutting down gracefully...');
-  server.close(() => {
-    console.log('Server closed.');
-    process.exit(0);
-  });
+  process.exit(0);
 });
 
-export default app;
+// Start all servers
+startServers();
+
+export { createApp, startServers };

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,15 +21,6 @@ const loadMappings = (): { [key: string]: number } => {
   }
 };
 
-// Create reverse mapping: port -> workflow_id
-const createPortToWorkflowMapping = (mappings: { [key: string]: number }): { [port: number]: string } => {
-  const reverseMap: { [port: number]: string } = {};
-  Object.entries(mappings).forEach(([workflowId, port]) => {
-    reverseMap[port] = workflowId;
-  });
-  return reverseMap;
-};
-
 // Ensure data directory exists
 const dataDir = path.join(__dirname, '..', 'data');
 if (!fs.existsSync(dataDir)) {
@@ -187,8 +178,7 @@ const createApp = (workflowId: string): Application => {
 // Main function to start all servers
 const startServers = () => {
   const mappings = loadMappings();
-  const portToWorkflowMapping = createPortToWorkflowMapping(mappings);
-  
+
   if (Object.keys(mappings).length === 0) {
     console.warn('No mappings found in mappings.json. Starting default server on port 3000.');
     // Start default server


### PR DESCRIPTION
This PR automatically adds a workflow_id based on the port that your LLM hits. For example, the default mappings.json looks like

```json
{
  "workflow_id_1": 3001,
  "workflow_id_2": 3002
}
```

This means that localhost:3001/v1/completions will output to the `data/workflow_id_1` folder, and localhost:3002/v1/completions will output to the `data/workflow_id_2` folder automatically. 