### PR TITLE
Support multiple ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-# OpenAI API Configuration
-OPENAI_API_BASE_URL=https://api.openai.com
-OPENAI_API_KEY=your_openai_api_key_here
-
-# Server Configuration
-PORT=36830

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cd MicroModel
 npm install
 ```
 
-2. Create `mappings.json` file (optional):
+2. Create `config.json` file (optional):
 ```json
 {
   "workflow_id_1": 3001,
@@ -35,20 +35,20 @@ PORT=36830
 npm run dev
 ```
 
-The server will automatically start multiple instances based on your `mappings.json`:
+The server will automatically start multiple instances based on your `config.json`:
 - Each port maps to a specific `workflow_id`
-- If no `mappings.json` exists, runs on port defined in the env
+- If no `config.json` exists, runs on port defined in the env
 
 ## Port-Based Workflow Mapping
 
-When you create a `mappings.json` file, MicroModel automatically:
+When you create a `config.json` file, MicroModel automatically:
 1. Starts multiple server instances - one for each port defined
 2. Auto-assigns workflow_id - based on which port receives the request
 3. Organizes data collection - each workflow gets its own data directory
 
 ### Example Setup
 
-With this `mappings.json`:
+With this `config.json`:
 ```json
 {
   "user_feedback": 3001,

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # MicroModel
 
-A simple proxy server that forwards OpenAI API requests and automatically saves conversations as training data in ChatML format.
+A simple proxy server that forwards OpenAI API requests and automatically saves conversations as training data in ChatML format. 
 
-**Note**: Currently only supports the `/v1/completions` endpoint.
+> [!NOTE]  
+> Currently only supports the `/v1/completions` endpoint.
+
+> [!IMPORTANT]  
+> Now supports per-workflow configuration with individual API hosts, keys, and ports.
 
 ## Quick Start
 
@@ -13,88 +17,111 @@ cd MicroModel
 npm install
 ```
 
-2. Create `config.json` file (optional):
+2. Create `config.json` file (required):
 ```json
 {
-  "workflow_id_1": 3001,
-  "workflow_id_2": 3002,
-  "training_batch_alpha": 3003,
-  "production_test": 3004
+  "default": {
+    "OPENAI_API_HOST": "http://localhost:11434",
+    "API_KEY": "",
+    "PORT": 3001
+  },
+  "custom_workflow": {
+    "OPENAI_API_HOST": "http://localhost:11434",
+    "API_KEY": "12345",
+    "PORT": 3002
+  }
 }
 ```
 
-3. Create `.env` file:
-```env
-OPENAI_API_BASE_URL=http://localhost:11434
-OPENAI_API_KEY=your-api-key
-PORT=36830
-```
-
-4. Start the server:
+3. Start the server:
 ```bash
 npm run dev
 ```
 
 The server will automatically start multiple instances based on your `config.json`:
-- Each port maps to a specific `workflow_id`
-- If no `config.json` exists, runs on port defined in the env
+- Each instance will automatically save the prompt / response to the workflow defined in the config.json
+- Each workflow has its own port, API host, and API key
+- All configuration must be in `config.json`
 
-## Port-Based Workflow Mapping
+## Per-Workflow Configuration
 
-When you create a `config.json` file, MicroModel automatically:
-1. Starts multiple server instances - one for each port defined
-2. Auto-assigns workflow_id - based on which port receives the request
-3. Organizes data collection - each workflow gets its own data directory
+Each workflow in `config.json` can have its own configuration:
 
-### Example Setup
+### Configuration Fields
+- **OPENAI_API_HOST**: The API endpoint to forward requests to
+- **API_KEY**: The API key for authentication (optional)
+- **PORT**: The port number for this workflow's server
 
-With this `config.json`:
+> [!NOTE]
+> If you are using Ollama / vLLM to generate your responses, you do not need to define an API_KEY
+
+### Multi-Provider Support
+You can configure different workflows to use different AI providers:
+
 ```json
 {
-  "user_feedback": 3001,
-  "automated_tests": 3002,
-  "production_logs": 3003
+  "local_llama": {
+    "OPENAI_API_HOST": "http://localhost:11434",
+    "API_KEY": "",
+    "PORT": 3001
+  },
+  "openai_gpt": {
+    "OPENAI_API_HOST": "https://api.openai.com",
+    "API_KEY": "sk-your-openai-key",
+    "PORT": 3002
+  },
+  "anthropic_claude": {
+    "OPENAI_API_HOST": "https://api.anthropic.com",
+    "API_KEY": "your-anthropic-key",
+    "PORT": 3003
+  }
 }
 ```
 
-You get three separate endpoints:
-- `http://localhost:3001/v1/completions` → automatically uses `workflow_id: "user_feedback"`
-- `http://localhost:3002/v1/completions` → automatically uses `workflow_id: "automated_tests"` 
-- `http://localhost:3003/v1/completions` → automatically uses `workflow_id: "production_logs"`
+The `model` and `workflow_id` will be saved to the ultimate JSONL file in their respective fields.
 
 ## Usage
 
-### Option 1: Port-Based Automatic Assignment (Recommended)
-Simply send requests to the mapped port - no need to include `workflow_id` in the body:
+### Automatic Workflow Assignment
+Each port automatically uses its configured workflow ID. Simply send requests to the appropriate port:
 
 ```bash
-# Automatically uses workflow_id: "user_feedback"
+# Uses workflow_id: "local_llama" and forwards to localhost:11434
 curl -X POST http://localhost:3001/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "qwen3:0.6b",
+    "model": "llama2",
+    "prompt": "Tell me a story"
+  }'
+
+# Uses workflow_id: "openai_gpt" and forwards to OpenAI API
+curl -X POST http://localhost:3002/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-3.5-turbo",
     "prompt": "Tell me a story"
   }'
 ```
 
-### Option 2: Manual workflow_id Assignment
-Send requests with explicit `workflow_id` (works on any port):
+### Manual Workflow Override
+You can override the automatic workflow assignment by including `workflow_id` in the request body:
 
 ```json
 {
-  "model": "qwen3:0.6b",
+  "model": "llama2",
   "prompt": "Tell me a story",
-  "workflow_id": "custom_workflow"
+  "workflow_id": "custom_experiment"
 }
 ```
 
-**Note**: Manual `workflow_id` in the request body overrides the port-based assignment.
+> [!IMPORTANT]
+> Entering in a manual `workflow_id` in the request body will override the port-based assignment. If you do not have a workflow_id defined in your config.json, then an error will occur.
 
 ## Data Collection
 
 Conversations are automatically saved in ChatML format:
-- With workflow_id: `data/${workflow_id}$/conversations.jsonl`
-- Without workflow_id: `data/default/conversations.jsonl`
+- Location: `data/${workflow_id}/data.jsonl`
+- Each workflow gets its own data directory
 
 Each saved conversation looks like:
 ```json
@@ -103,16 +130,56 @@ Each saved conversation looks like:
     {"role": "user", "content": "Tell me a story"},
     {"role": "assistant", "content": "Once upon a time..."}
   ],
-  "timestamp": "2025-08-23T19:30:00.000Z",
-  "model": "qwen3:0.6b",
-  "workflow_id": "my-training-data"
+  "timestamp": "2025-08-24T10:30:00.000Z",
+  "endpoint": "/v1/completions",
+  "model": "llama2",
+  "workflow_id": "local_llama"
 }
 ```
 
+This data can be used to easily fine tune a model using a platform like [unsloth](https://unsloth.ai/).
+
 ## API Endpoints
 
-- `POST /v1/completions` - Proxy endpoint (saves training data)
-- `GET /health` - Health check
-- `GET /` - Service info
+### Per-Workflow Endpoints
+Each configured workflow provides these endpoints:
+- `POST /v1/completions` - Proxy endpoint with automatic logging
+- `GET /health` - Health check (shows workflow configuration)
+- `GET /` - Service info (shows workflow configuration)
 
-That's it! The proxy forwards your requests and collects training data automatically.
+### Health Check Response
+```json
+{
+  "status": "OK",
+  "timestamp": "2025-08-24T10:30:00.000Z",
+  "service": "OpenAI Proxy Service",
+  "workflow_id": "local_llama",
+  "api_host": "http://localhost:11434",
+  "port": 3001
+}
+```
+
+## Configuration Reference
+
+### config.json Structure
+```json
+{
+  "workflow_name": {
+    "OPENAI_API_HOST": "string (required) - API endpoint URL",
+    "API_KEY": "string (optional) - API key for authentication", 
+    "PORT": "number (required) - Port for this workflow's server"
+  }
+}
+```
+
+### Validation
+The system validates that:
+- `config.json` file exists
+- Each workflow has required `OPENAI_API_HOST` and `PORT` fields
+- Port numbers are valid integers
+- No port conflicts between workflows
+
+## Error Handling
+- Missing `config.json`: Server exits with configuration example
+- Invalid configuration: Server exits with specific error message
+- API request failures: Forwarded to client with original status codes

--- a/config.json
+++ b/config.json
@@ -1,12 +1,12 @@
 {
   "default": {
     "OPENAI_API_HOST": "http://localhost:11434",
-    "OPENAI_API_KEY": "",
+    "API_KEY": "",
     "PORT": 3001
   },
   "custom_workflow": {
     "OPENAI_API_HOST": "http://localhost:11434",
-    "OPENAI_API_KEY": "12345",
+    "API_KEY": "12345",
     "PORT": 3002
   }
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,12 @@
+{
+  "default": {
+    "OPENAI_API_HOST": "http://localhost:11434",
+    "OPENAI_API_KEY": "",
+    "PORT": 3001
+  },
+  "custom_workflow": {
+    "OPENAI_API_HOST": "http://localhost:11434",
+    "OPENAI_API_KEY": "12345",
+    "PORT": 3002
+  }
+}

--- a/mappings.json
+++ b/mappings.json
@@ -1,4 +1,0 @@
-{
-  "workflow_id_1": 3001,
-  "workflow_id_2": 3002
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,9 @@ import fs from 'fs';
 import path from 'path';
 import { setupRoutes } from './routes';
 
-// Load environment variables
-dotenv.config();
-
-const OPENAI_API_BASE_URL = process.env.OPENAI_API_BASE_URL || 'https://api.openai.com';
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+// Load environment variables from ../.env if not found
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+const OPENAI_API_BASE_URL = process.env.OPENAI_API_BASE_URL;
 
 // Load mappings from mappings.json
 const loadMappings = (): { [key: string]: number } => {
@@ -73,10 +71,6 @@ const startServers = () => {
 
     setupErrorHandling(server, port);
   });
-
-  if (!OPENAI_API_KEY) {
-    console.warn('Warning: OPENAI_API_KEY not set in environment variables');
-  }
 };
 
 // Setup error handling for a server

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
-import express, { Application, Request, Response } from 'express';
+import express, { Application } from 'express';
 import dotenv from 'dotenv';
 import fs from 'fs';
 import path from 'path';
+import { setupRoutes } from './routes';
 
 // Load environment variables
 dotenv.config();
@@ -21,52 +22,6 @@ const loadMappings = (): { [key: string]: number } => {
   }
 };
 
-// Ensure data directory exists
-const dataDir = path.join(__dirname, '..', 'data');
-if (!fs.existsSync(dataDir)) {
-  fs.mkdirSync(dataDir, { recursive: true });
-}
-
-// Logging utility
-const logRequestResponse = (prompt: any, response: any, endpoint: string, workflowId?: string) => {
-  // Save to JSONL file in ChatML format
-  try {
-    const chatMLEntry = {
-      messages: [
-        {
-          role: "user",
-          content: prompt.prompt || JSON.stringify(prompt)
-        },
-        {
-          role: "assistant", 
-          content: response.choices?.[0]?.text || response.choices?.[0]?.message?.content || JSON.stringify(response)
-        }
-      ],
-      timestamp: new Date().toISOString(),
-      endpoint: endpoint,
-      model: prompt.model || 'unknown',
-      workflow_id: workflowId || 'default'
-    };
-
-    // Create workflow-specific directory
-    const workflowDir = workflowId 
-      ? path.join(dataDir, workflowId)
-      : path.join(dataDir, 'default');
-    
-    if (!fs.existsSync(workflowDir)) {
-      fs.mkdirSync(workflowDir, { recursive: true });
-    }
-
-    const jsonlLine = JSON.stringify(chatMLEntry) + '\n';
-    const filePath = path.join(workflowDir, 'data.jsonl');
-    
-    fs.appendFileSync(filePath, jsonlLine);
-    console.log(`Saved conversation to ${filePath} (workflow: ${workflowId || 'default'})`);
-  } catch (error) {
-    console.error('Error saving conversation:', error);
-  }
-};
-
 // Create an Express app with workflow-specific routing
 const createApp = (workflowId: string): Application => {
   const app: Application = express();
@@ -75,102 +30,8 @@ const createApp = (workflowId: string): Application => {
   app.use(express.json({ limit: '10mb' }));
   app.use(express.urlencoded({ extended: true }));
 
-  // Proxy route for OpenAI /v1/completions
-  app.post('/v1/completions', async (req: Request, res: Response) => {
-    try {
-      const requestBody = req.body;
-      // Use the workflow_id from the port mapping, but allow override from request body
-      const finalWorkflowId = requestBody.workflow_id || workflowId;
-      
-      // Remove workflow_id from request body before forwarding to API
-      const forwardBody = { ...requestBody };
-      delete forwardBody.workflow_id;
-      
-      // Log the incoming request
-      console.log(`Proxying request to ${OPENAI_API_BASE_URL}/v1/completions for ${finalWorkflowId}`);
-      
-      // Forward request to OpenAI API
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 60000); // 1 minute timeout
-      
-      // Prepare headers, filtering out problematic ones
-      const forwardHeaders: Record<string, string> = {};
-      Object.entries(req.headers).forEach(([key, value]) => {
-        if (typeof value === 'string' && key.toLowerCase() !== 'host' && key.toLowerCase() !== 'content-length') {
-          forwardHeaders[key] = value;
-        }
-      });
-      
-      const response = await fetch(
-        `${OPENAI_API_BASE_URL}/v1/completions`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...forwardHeaders
-          },
-          body: JSON.stringify(forwardBody),
-          signal: controller.signal
-        }
-      );
-      
-      clearTimeout(timeoutId);
-      
-      if (!response.ok) {
-        const errorData = await response.json();
-        return res.status(response.status).json(errorData);
-      }
-      
-      const responseData = await response.json();
-
-      // Log the prompt and response with workflow_id
-      logRequestResponse(requestBody, responseData, '/v1/completions', finalWorkflowId);
-
-      // Return the response to the client
-      res.status(response.status).json(responseData);
-
-    } catch (error: any) {
-      console.error('Error proxying request:', error.message);
-      
-      if (error.name === 'AbortError') {
-        // Request was aborted due to timeout
-        res.status(408).json({ 
-          error: 'Request timeout',
-          message: 'Request timed out after 60 seconds'
-        });
-      } else {
-        // Internal server error
-        res.status(500).json({ 
-          error: 'Internal proxy server error',
-          message: error.message 
-        });
-      }
-    }
-  });
-
-  // Health check endpoint
-  app.get('/health', (req: Request, res: Response) => {
-    res.json({ 
-      status: 'OK', 
-      timestamp: new Date().toISOString(),
-      service: 'OpenAI Proxy Service',
-      workflow_id: workflowId
-    });
-  });
-
-  // Basic info endpoint
-  app.get('/', (req: Request, res: Response) => {
-    res.json({
-      service: 'OpenAI Proxy Service',
-      description: 'Forwards requests to OpenAI API while logging prompts and responses',
-      workflow_id: workflowId,
-      endpoints: {
-        'POST /v1/completions': 'Proxy for OpenAI chat completions',
-        'GET /health': 'Health check',
-        'GET /': 'Service information'
-      }
-    });
-  });
+  // Setup routes
+  setupRoutes(app, workflowId);
 
   return app;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ const startServers = () => {
       console.log(`OpenAI Proxy Server is running on port ${config.PORT}`);
       console.log(`Workflow ID: ${workflowId}`);
       console.log(`Forwarding requests to: ${config.OPENAI_API_HOST}`);
-      console.log(`API Key: ${config.API_KEY ? '***configured***' : 'not set'}`);
+      console.log(`API Key: ${config.API_KEY ? 'SET' : 'NOT SET'}`);
       console.log('='.repeat(60));
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,12 +62,12 @@ const startServers = () => {
     console.error(JSON.stringify({
       "default": {
         "OPENAI_API_HOST": "http://localhost:11434",
-        "OPENAI_API_KEY": "",
+        "API_KEY": "",
         "PORT": 3000
       },
       "my_workflow": {
         "OPENAI_API_HOST": "http://localhost:11434",
-        "OPENAI_API_KEY": "your-api-key",
+        "API_KEY": "your-api-key",
         "PORT": 3001
       }
     }, null, 2));
@@ -88,7 +88,7 @@ const startServers = () => {
       console.log(`OpenAI Proxy Server is running on port ${config.PORT}`);
       console.log(`Workflow ID: ${workflowId}`);
       console.log(`Forwarding requests to: ${config.OPENAI_API_HOST}`);
-      console.log(`API Key: ${config.OPENAI_API_KEY ? '***configured***' : 'not set'}`);
+      console.log(`API Key: ${config.API_KEY ? '***configured***' : 'not set'}`);
       console.log('='.repeat(60));
     });
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,161 @@
+import { Application, Request, Response } from 'express';
+import fs from 'fs';
+import path from 'path';
+
+const OPENAI_API_BASE_URL = process.env.OPENAI_API_BASE_URL || 'https://api.openai.com';
+
+// Ensure data directory exists
+const dataDir = path.join(__dirname, '..', 'data');
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir, { recursive: true });
+}
+
+// Logging utility
+const logRequestResponse = (prompt: any, response: any, endpoint: string, workflowId?: string) => {
+  // Save to JSONL file in ChatML format
+  try {
+    const chatMLEntry = {
+      messages: [
+        {
+          role: "user",
+          content: prompt.prompt || JSON.stringify(prompt)
+        },
+        {
+          role: "assistant", 
+          content: response.choices?.[0]?.text || response.choices?.[0]?.message?.content || JSON.stringify(response)
+        }
+      ],
+      timestamp: new Date().toISOString(),
+      endpoint: endpoint,
+      model: prompt.model || 'unknown',
+      workflow_id: workflowId || 'default'
+    };
+
+    // Create workflow-specific directory
+    const workflowDir = workflowId 
+      ? path.join(dataDir, workflowId)
+      : path.join(dataDir, 'default');
+    
+    if (!fs.existsSync(workflowDir)) {
+      fs.mkdirSync(workflowDir, { recursive: true });
+    }
+
+    const jsonlLine = JSON.stringify(chatMLEntry) + '\n';
+    const filePath = path.join(workflowDir, 'data.jsonl');
+    
+    fs.appendFileSync(filePath, jsonlLine);
+    console.log(`Saved conversation to ${filePath} (workflow: ${workflowId || 'default'})`);
+  } catch (error) {
+    console.error('Error saving conversation:', error);
+  }
+};
+
+// Completions route handler
+export const completionsHandler = (workflowId: string) => {
+  return async (req: Request, res: Response) => {
+    try {
+      const requestBody = req.body;
+      // Use the workflow_id from the port mapping, but allow override from request body
+      const finalWorkflowId = requestBody.workflow_id || workflowId;
+      
+      // Remove workflow_id from request body before forwarding to API
+      const forwardBody = { ...requestBody };
+      delete forwardBody.workflow_id;
+      
+      // Log the incoming request
+      console.log(`Proxying request to ${OPENAI_API_BASE_URL}/v1/completions for ${finalWorkflowId}`);
+      
+      // Forward request to OpenAI API
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 60000); // 1 minute timeout
+      
+      // Prepare headers, filtering out problematic ones
+      const forwardHeaders: Record<string, string> = {};
+      Object.entries(req.headers).forEach(([key, value]) => {
+        if (typeof value === 'string' && key.toLowerCase() !== 'host' && key.toLowerCase() !== 'content-length') {
+          forwardHeaders[key] = value;
+        }
+      });
+      
+      const response = await fetch(
+        `${OPENAI_API_BASE_URL}/v1/completions`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...forwardHeaders
+          },
+          body: JSON.stringify(forwardBody),
+          signal: controller.signal
+        }
+      );
+      
+      clearTimeout(timeoutId);
+      
+      if (!response.ok) {
+        const errorData = await response.json();
+        return res.status(response.status).json(errorData);
+      }
+      
+      const responseData = await response.json();
+
+      // Log the prompt and response with workflow_id
+      logRequestResponse(requestBody, responseData, '/v1/completions', finalWorkflowId);
+
+      // Return the response to the client
+      res.status(response.status).json(responseData);
+
+    } catch (error: any) {
+      console.error('Error proxying request:', error.message);
+      
+      if (error.name === 'AbortError') {
+        // Request was aborted due to timeout
+        res.status(408).json({ 
+          error: 'Request timeout',
+          message: 'Request timed out after 60 seconds'
+        });
+      } else {
+        // Internal server error
+        res.status(500).json({ 
+          error: 'Internal proxy server error',
+          message: error.message 
+        });
+      }
+    }
+  };
+};
+
+// Health check route handler
+export const healthHandler = (workflowId: string) => {
+  return (req: Request, res: Response) => {
+    res.json({ 
+      status: 'OK', 
+      timestamp: new Date().toISOString(),
+      service: 'OpenAI Proxy Service',
+      workflow_id: workflowId
+    });
+  };
+};
+
+// Root route handler
+export const rootHandler = (workflowId: string) => {
+  return (req: Request, res: Response) => {
+    res.json({
+      service: 'OpenAI Proxy Service',
+      description: 'Forwards requests to OpenAI API while logging prompts and responses',
+      workflow_id: workflowId,
+      endpoints: {
+        'POST /v1/completions': 'Proxy for OpenAI chat completions',
+        'GET /health': 'Health check',
+        'GET /': 'Service information'
+      }
+    });
+  };
+};
+
+// Setup routes for an Express app
+export const setupRoutes = (app: Application, workflowId: string) => {
+  app.post('/v1/completions', completionsHandler(workflowId));
+  app.get('/health', healthHandler(workflowId));
+  app.get('/', rootHandler(workflowId));
+};

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,7 +1,10 @@
 import { Application, Request, Response } from 'express';
 import fs from 'fs';
 import path from 'path';
+import dotenv from 'dotenv';
 
+// Load environment variables from ../.env if not found
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 const OPENAI_API_BASE_URL = process.env.OPENAI_API_BASE_URL || 'https://api.openai.com';
 
 // Ensure data directory exists

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -77,8 +77,8 @@ export const completionsHandler = (workflowId: string, config: WorkflowConfig) =
       });
 
       // Add API key if configured
-      if (config.OPENAI_API_KEY) {
-        forwardHeaders['Authorization'] = `Bearer ${config.OPENAI_API_KEY}`;
+      if (config.API_KEY) {
+        forwardHeaders['Authorization'] = `Bearer ${config.API_KEY}`;
       }
       
       const response = await fetch(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export interface WorkflowConfig {
   OPENAI_API_HOST: string;
-  OPENAI_API_KEY: string;
+  API_KEY: string;
   PORT: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export interface WorkflowConfig {
+  OPENAI_API_HOST: string;
+  OPENAI_API_KEY: string;
+  PORT: number;
+}
+
+export interface WorkflowMappings {
+  [workflowId: string]: WorkflowConfig;
+}


### PR DESCRIPTION
The new `config.json` handler allows for complex configurations like:

```json
{
  "default": {
    "OPENAI_API_HOST": "http://localhost:11434",
    "API_KEY": "",
    "PORT": 3001
  },
  "custom_workflow": {
    "OPENAI_API_HOST": "http://localhost:11434",
    "API_KEY": "12345",
    "PORT": 3002
  }
}
```

This means that you can now change the OPENAI_API_HOST and the API_KEY independent of each proxy configuration. As an ease of use measure, there are no more default configurations, only what is present in the `config.json` file.